### PR TITLE
Fixed window double-free

### DIFF
--- a/neo/ui/FeedAlertWindow.h
+++ b/neo/ui/FeedAlertWindow.h
@@ -12,7 +12,7 @@ class idFeedAlertWindow : public idWindow
 public:
 	idFeedAlertWindow(idUserInterfaceLocal *gui) : idWindow(gui){ CommonInit(); }
 	idFeedAlertWindow(idDeviceContext *d, idUserInterfaceLocal *gui) : idWindow(d, gui){ CommonInit(); }
-	virtual ~idFeedAlertWindow(){ disposedState = 0; idWindow::~idWindow(); }
+	virtual ~idFeedAlertWindow() { disposedState = 0; }
 	virtual bool ParseInternalVar(const char* name, idParser* src);
 	virtual void PostParse();
 	virtual void Redraw(float x, float y){ Update(); idWindow::Redraw(x, y); }


### PR DESCRIPTION
idFeedAlertWindow was calling its base class destructor, which is unnecessary and caused a double-free. This fixes it.

ASan doesn't show it leaking any memory, so I am led to believe it's fine.